### PR TITLE
Reorganize includes

### DIFF
--- a/src/custombutton.cpp
+++ b/src/custombutton.cpp
@@ -1,5 +1,7 @@
 #include "custombutton.h"
+
 #include <QFontMetrics>
+#include <QPainter>
 
 CustomButton::CustomButton(const QString &text1, const QString &text2, const QString &text3, const QColor &lineColor, QWidget *parent)
     : QPushButton(parent), text1(text1), text2(text2), text3(text3), lineColor(lineColor) {

--- a/src/custombutton.h
+++ b/src/custombutton.h
@@ -1,8 +1,9 @@
-#ifndef CUSTOMBUTTON_H
-#define CUSTOMBUTTON_H
+#pragma once
 
+#include <QColor>
 #include <QPushButton>
-#include <QPainter>
+#include <QString>
+#include <QWidget>
 
 class CustomButton : public QPushButton {
     Q_OBJECT
@@ -18,12 +19,9 @@ protected:
     void setText3(const QString &newText3);
     void adjustWidthToFitText();
 
-
 private:
     QString text1;
     QString text2;
     QString text3;
     QColor lineColor;
 };
-
-#endif

--- a/src/jsonparser.cpp
+++ b/src/jsonparser.cpp
@@ -1,8 +1,6 @@
 #include "jsonparser.h"
 
-JsonParser::JsonParser()
-{
-}
+#include <QStringList>
 
 QVector<QPair<QString, int>> JsonParser::parse(const QString &json)
 {

--- a/src/jsonparser.h
+++ b/src/jsonparser.h
@@ -1,20 +1,16 @@
-#ifndef JSONPARSER_H
-#define JSONPARSER_H
+#pragma once
 
 #include <QString>
 #include <QVector>
-#include <QStringList>
 #include <QPair>
 
 class JsonParser
 {
 public:
-    JsonParser();
+    JsonParser() = default;
 
     QVector<QPair<QString, int>> parse(const QString &json);
 
 private:
     QString removeQuotes(const QString &s);
 };
-
-#endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,10 +1,16 @@
 #include "mainwindow.h"
 
+#include <QDesktopServices>
+#include <QFileDialog>
+#include <QJsonDocument>
+#include <QMessageBox>
+#include <QUrl>
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
+    , initializing(true)
     , ui(new Ui::MainWindow)
     , settings("qdiskinfo", "qdiskinfo")
-    , initializing(true)
 {
     ui->setupUi(this);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8,9 +8,9 @@
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
-    , initializing(true)
     , ui(new Ui::MainWindow)
     , settings("qdiskinfo", "qdiskinfo")
+    , initializing(true)
 {
     ui->setupUi(this);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,7 +4,6 @@
 #include <QActionGroup>
 #include <QJsonObject>
 #include <QMainWindow>
-#include <QMainWindow>
 #include <QMouseEvent>
 #include <QSettings>
 #include <QTableWidget>
@@ -34,14 +33,23 @@ public:
 
 private slots:
     void on_actionQuit_triggered();
+
     void on_actionSave_JSON_triggered();
+
     void on_actionGitHub_triggered();
+
     void on_actionRescan_Refresh_triggered();
+
     void on_actionAbout_triggered();
+
     void on_actionIgnore_C4_Reallocation_Event_Count_toggled(bool enabled);
+
     void on_actionHEX_toggled(bool enabled);
+
     void on_actionUse_Fahrenheit_toggled(bool enabled);
+
     void on_actionCyclic_Navigation_toggled(bool arg1);
+
     void on_actionUse_GB_instead_of_TB_toggled(bool arg1);
 
 private:

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -80,5 +80,3 @@ private:
     void addSmartAttributesTable(const QJsonArray &attributes);
     void mousePressEvent(QMouseEvent*);
 };
-
-#endif

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,7 +1,14 @@
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
+#include <QAction>
+#include <QActionGroup>
+#include <QJsonObject>
 #include <QMainWindow>
+#include <QMainWindow>
+#include <QMouseEvent>
+#include <QSettings>
+#include <QTableWidget>
+#include <QWidget>
 #include <cmath>
 
 #include "statusdot.h"
@@ -27,23 +34,14 @@ public:
 
 private slots:
     void on_actionQuit_triggered();
-
     void on_actionSave_JSON_triggered();
-
     void on_actionGitHub_triggered();
-
     void on_actionRescan_Refresh_triggered();
-
     void on_actionAbout_triggered();
-
     void on_actionIgnore_C4_Reallocation_Event_Count_toggled(bool enabled);
-
     void on_actionHEX_toggled(bool enabled);
-
     void on_actionUse_Fahrenheit_toggled(bool enabled);
-
     void on_actionCyclic_Navigation_toggled(bool arg1);
-
     void on_actionUse_GB_instead_of_TB_toggled(bool arg1);
 
 private:
@@ -85,4 +83,3 @@ private:
     void addSmartAttributesTable(const QJsonArray &attributes);
     void mousePressEvent(QMouseEvent*);
 };
-#endif

--- a/src/statusdot.h
+++ b/src/statusdot.h
@@ -1,5 +1,4 @@
-#ifndef STATUSDOT_H
-#define STATUSDOT_H
+#pragma once
 
 #include <QPainter>
 #include <QStyleOptionViewItem>
@@ -16,5 +15,3 @@ public:
                const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;
 };
-
-#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,14 @@
 #include "utils.h"
 
-utils::utils() {}
+#include <QAbstractButton>
+#include <QApplication>
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
+#include <QProcess>
+#include <QPushButton>
+#include <QTimer>
 
 void utils::clearButtonGroup(QButtonGroup* buttonGroup, QHBoxLayout* horizontalLayout, QSpacerItem* buttonStretch, QMenu* menuDisk)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,33 +1,15 @@
-#ifndef UTILS_H
-#define UTILS_H
+#pragma once
 
-#include <QMainWindow>
-#include <QProcess>
-#include <QWidget>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
 #include <QButtonGroup>
-#include <QAction>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QDesktopServices>
-#include <QUrl>
-#include <QTimer>
-#include <QSettings>
-#include <QMouseEvent>
-#include <QActionGroup>
 #include <QHBoxLayout>
-#include <QSpacerItem>
-#include <QPushButton>
-#include <QAbstractButton>
+#include <QJsonArray>
 #include <QMenu>
-#include <QApplication>
+#include <QSpacerItem>
 
 class utils
 {
 public:
-    utils();
+    utils() = default;
 
     void clearButtonGroup(QButtonGroup* buttonGroup, QHBoxLayout* horizontalLayout, QSpacerItem* buttonStretch, QMenu* menuDisk);
     QString getSmartctlPath(bool initializing);
@@ -38,5 +20,3 @@ public:
     void selfTestHandler(const QString &mode, const QString &name, const QString &minutes);
     QString toTitleCase(const QString& sentence);
 };
-
-#endif // UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,5 +20,3 @@ public:
     void selfTestHandler(const QString &mode, const QString &name, const QString &minutes);
     QString toTitleCase(const QString& sentence);
 };
-
-#endif


### PR DESCRIPTION
This reorganizes the includes so that only what is used is included in each file. It also uses `#pragma once` instead of include guards.