### PR TITLE
Append compiler flags instead of overwriting them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTORCC ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wuseless-cast -Wconversion -Wsign-conversion -Wshadow")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wuseless-cast -Wconversion -Wsign-conversion -Wshadow")
 
 if(NOT DEFINED QT_VERSION_MAJOR)
     set(QT_VERSION_MAJOR 6)


### PR DESCRIPTION
Hi, thanks for QDiskInfo 

When packaging, I noticed that my locally set CFLAGS get overwritten by [set(CMAKE_CXX_FLAGS](https://github.com/edisionnano/QDiskInfo/blob/ec0ea8fa0ec10baab2f2df60aadbe9c2f1ca99b5/CMakeLists.txt#L11C1-L11C21) in CMakeLists.txt
resulting in total compiler flags
```
-Wall -Wextra -Wpedantic -Wuseless-cast -Wconversion -Wsign-conversion -Wshadow
```

I therefore propose using [add_compile_options](https://cmake.org/cmake/help/latest/command/add_compile_options.html) instead, which will honor locally set CFLAGS resulting for example (in my case) in 
```
-march=native -O2 -pipe -flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing -Wall -Wextra -Wpedantic -Wuseless-cast -Wconversion -Wsign-conversion -Wshadow
```
