### PR TITLE
Update compilation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The icon is a modified version of the KDE Partition Manager logo which is availa
 
 ## Compiling and Installing
 ### Compilation and Runtime Dependencies
-Ubuntu and based distros (Mint, Pop!_OS, etc.)
+Debian and Debian-based distros (Ubuntu, Mint, Pop!_OS, etc.)
 ```sh
 sudo apt install build-essential cmake git libgl1-mesa-dev libxkbcommon-dev qt6-base-dev qt6-tools-dev qt6-wayland smartmontools
 ```


### PR DESCRIPTION
Ubuntu is forked from Debian, which is why it uses the Debian packaging system.

Sure, I'd hope anybody using a Debian-based distro would know it's based on Debian (and therefore should use apt for package management), but you never know. Changed language to be more specific.