### PR TITLE
Fix some issues with appimage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies for glibc
       run: |
         sudo apt update
-        sudo apt install -y qt6-base-dev qt6-tools-dev qt6-svg-dev libgl1-mesa-dev libxkbcommon-dev libvulkan-dev qmake6 smartmontools
+        sudo apt install -y qt6-base-dev qt6-tools-dev qt6-svg-dev libgl1-mesa-dev libxkbcommon-dev libvulkan-dev qmake6 smartmontools qt6ct
       if: ${{ matrix.clib == 'glibc' }}
     - name: Install dependencies for musl
       run: |
@@ -54,6 +54,10 @@ jobs:
         cp build/QDiskInfo AppDir/usr/bin/
         cp dist/QDiskInfo.desktop AppDir/usr/share/applications
         cp dist/QDiskInfo.svg AppDir/QDiskInfo.svg
+
+        mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
+        cp -r /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes \
+          ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
         
         ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
         cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies for glibc
       run: |
         sudo apt update
-        sudo apt install -y qt6-base-dev qt6-tools-dev qt6-svg-dev libgl1-mesa-dev libxkbcommon-dev libvulkan-dev qmake6 smartmontools qt6ct
+        sudo apt install -y qt6-base-dev qt6-tools-dev qt6-svg-dev libgl1-mesa-dev libxkbcommon-dev libvulkan-dev qmake6 smartmontools qt6ct patchelf
       if: ${{ matrix.clib == 'glibc' }}
     - name: Install dependencies for musl
       run: |
@@ -58,10 +58,13 @@ jobs:
         ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
         cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
 
-        mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
-        ls /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
-        cp -r /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
-        ls ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
+        # deploy qt6ct
+        mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/../styles
+        cp /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/libqt6ct.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
+        cp /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
+
+        # HACK
+        patchelf --set-rpath 'atchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/*
 
         ./appimagetool-static.AppImage AppDir
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,12 +60,12 @@ jobs:
 
         # deploy qt6ct
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/../styles
-        cp /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/libqt6ct.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
-        cp /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
-        cp /usr/lib/x86_64-linux-gnu/libqt6ct* ./AppDir/usr/lib/x86_64-linux-gnu
+        cp -v /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/libqt6ct.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
+        cp -v /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
+        cp -v /usr/lib/x86_64-linux-gnu/libqt6ct* ./AppDir/lib/x86_64-linux-gnu
 
         # HACK
-        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/* ./AppDir/usr/lib/x86_64-linux-gnu/libqt6ct*
+        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/* ./AppDir/lib/x86_64-linux-gnu/libqt6ct*
 
         ./appimagetool-static.AppImage AppDir
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
     - name: Upload AppImage
       uses: actions/upload-artifact@v4
       with:
-        name: QDiskInfo-${{ matrix.clib }}-AppImage
+        name: QDiskInfo-anylinux-AppImage
         path: ./QDiskInfo*.AppImage
 
     - name: Upload Binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,9 +62,10 @@ jobs:
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/../styles
         cp /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/libqt6ct.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
         cp /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
+        cp /usr/lib/x86_64-linux-gnu/libqt6ct* ./AppDir/usr/lib/x86_64-linux-gnu
 
         # HACK
-        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/*
+        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/* ./AppDir/usr/lib/x86_64-linux-gnu/libqt6ct*
 
         ./appimagetool-static.AppImage AppDir
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,6 @@ jobs:
         cp dist/QDiskInfo.svg AppDir/QDiskInfo.svg
         
         ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
-        cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
 
         # deploy qt6ct
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/../styles

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         chmod a+x *.AppImage
         chmod a+x .github/scripts/smartctl
          
-        mkdir -p AppDir/usr/bin
+        mkdir -p AppDir/usr/bin/../share/applications
         cp build/QDiskInfo AppDir/usr/bin/
         cp dist/QDiskInfo.desktop AppDir/usr/share/applications
         cp dist/QDiskInfo.svg AppDir/QDiskInfo.svg

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
         cp /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
 
         # HACK
-        patchelf --set-rpath 'atchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/*
+        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/*
 
         ./appimagetool-static.AppImage AppDir
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,21 +45,19 @@ jobs:
 
     - name: Package AppImage
       run: |
-        curl -sSfLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-static-x86_64.AppImage"
-        curl -sSfLO "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-static-x86_64.AppImage"
+        export APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 VERSION=${{ matrix.clib }}
         curl -sSfL "https://github.com/probonopd/go-appimage/releases/download/832/appimagetool-823-x86_64.AppImage" -o appimagetool-static.AppImage
         chmod a+x *.AppImage
         chmod a+x .github/scripts/smartctl
          
         mkdir -p AppDir/usr/bin
         cp build/QDiskInfo AppDir/usr/bin/
-        cp .github/scripts/smartctl AppDir/usr/bin/
-        cp dist/QDiskInfo.desktop AppDir/
+        cp dist/QDiskInfo.desktop AppDir/usr/share/applications
         cp dist/QDiskInfo.svg AppDir/QDiskInfo.svg
         
-        APPIMAGE_EXTRACT_AND_RUN=1 NO_STRIP=1 QMAKE=/usr/bin/qmake6 ARCH=x86_64 ./linuxdeploy-static-x86_64.AppImage --appdir=AppDir/ -d AppDir/QDiskInfo.desktop -i AppDir/QDiskInfo.svg -e AppDir/usr/bin/QDiskInfo --plugin qt
-        echo 'export PATH="$this_dir"/usr/bin:"$PATH"' >> AppDir/apprun-hooks/linuxdeploy-plugin-qt-hook.sh
-        APPIMAGE_EXTRACT_AND_RUN=1 VERSION=${{ matrix.clib }} QMAKE=/usr/bin/qmake6 ARCH=x86_64 ./appimagetool-static.AppImage AppDir/
+        ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
+        cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
+        ./appimagetool-static.AppImage AppDir
 
     - name: Upload AppImage
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,13 +54,14 @@ jobs:
         cp build/QDiskInfo AppDir/usr/bin/
         cp dist/QDiskInfo.desktop AppDir/usr/share/applications
         cp dist/QDiskInfo.svg AppDir/QDiskInfo.svg
+        
+        ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
+        cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
 
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
         cp -r /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes \
           ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
-        
-        ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
-        cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
+
         ./appimagetool-static.AppImage AppDir
 
     - name: Upload AppImage

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Package AppImage
       run: |
-        export APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 VERSION=${{ matrix.clib }}
+        export APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 VERSION=anylinux
         curl -sSfL "https://github.com/probonopd/go-appimage/releases/download/832/appimagetool-823-x86_64.AppImage" -o appimagetool-static.AppImage
         chmod a+x *.AppImage
         chmod a+x .github/scripts/smartctl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,8 +59,9 @@ jobs:
         cp .github/scripts/smartctl AppDir/usr/bin/ # done afterwards because patchelf errors out static bins
 
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
-        cp -r /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes \
-          ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
+        ls /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
+        cp -r /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
+        ls ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins
 
         ./appimagetool-static.AppImage AppDir
 


### PR DESCRIPTION
You were already downloading go-appimage, I just used it to deploy everything instead.

The produced appimage works on both glibc and musl systems since I used `-s deploy` which bundles everything, including the `ld-*.so`.

Also the musl appimage build is broken right now because go-appimage can't find the Qt plugins on alpine, doesn't matter anyway since the appimage made in ubuntu works on alpine as well.

I manually added the qt6ct plugin to have working dark theme, however this isn't perfect yet as it would only work for the people that use qt6ct, but maybe something similar can be done for other themes: 

![image](https://github.com/user-attachments/assets/49580792-c20c-4af2-940c-b1284377de1d)

(I don't know what that Broken filename error is about btw, so far everything seems to work)

Also go-appimage already deploys the static appimage runtime, you don't need `libfuse2` (and shouldn't have needed it before I changed it either since go-appimage was being used to turn the AppDir into an appimage).

You still need a `fusermount` or `fusermount3` binary, which ubuntu should have `fuse3` shipped by default. 

Not sure if wayland works now, since I don't use wayland I can't test.

I also had to remove the `smartctl` binary from the appimage because it did not work, for some reason it only works when the appimage is extracted, I tested unsetting the env variables `APPIMAGE APPDIR OWD ARGV0` which is one of the few things the appimage runtime sets, and it still didn't work. I have no idea but this seems like a fuse limitation with smartctl? 

The issue is not with the smartctl binary, as I copied it to my `$XDG_BIN_HOME` and repackaged the appimage and it works just in case. 

This issue of smartctl can be fixed by making a hook that detects if smartctl isn't in PATH, if it is not then it downloads the binary to a temp location and adds that location to path, like I do [here](https://github.com/Samueru-sama/mpv-AppImage/blob/main/yt-dlp_hook.sh) with yt-dlp for example. 
