### PR TITLE
deploy appimage with sharun

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,18 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y qt6-base-dev qt6-tools-dev qt6-svg-dev libgl1-mesa-dev libxkbcommon-dev libvulkan-dev qmake6 smartmontools qt6ct patchelf
+        sudo apt install -y \
+          libgl1-mesa-dev   \
+          libvulkan-dev     \
+          libxkbcommon-dev  \
+          patchelf          \
+          qmake6            \
+          qt6-base-dev      \
+          qt6ct             \
+          qt6-svg-dev       \
+          qt6-tools-dev     \
+          smartmontools     \
+          wget
 
     - name: Build
       run: |
@@ -28,28 +39,9 @@ jobs:
 
     - name: Package AppImage
       run: |
-        export APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 VERSION=anylinux
-        curl -sSfL "https://github.com/probonopd/go-appimage/releases/download/832/appimagetool-823-x86_64.AppImage" -o appimagetool-static.AppImage
-        chmod a+x *.AppImage
-         
-        mkdir -p AppDir/usr/bin/../share/applications
-        cp build/QDiskInfo AppDir/usr/bin/
-        cp dist/QDiskInfo.desktop AppDir/usr/share/applications
-        cp dist/QDiskInfo-256x256.png AppDir/QDiskInfo.png
+        chmod +x ./qdiskinfo-appimage.sh
+        ./qdiskinfo-appimage.sh
         
-        ./appimagetool-static.AppImage -s deploy AppDir/usr/share/applications/*.desktop
-
-        # deploy qt6ct
-        mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/../styles
-        cp -v /usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/libqt6ct.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes
-        cp -v /usr/lib/x86_64-linux-gnu/qt6/plugins/styles/libqt6ct-style.so ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles
-        cp -v /usr/lib/x86_64-linux-gnu/libqt6ct* ./AppDir/lib/x86_64-linux-gnu
-
-        # HACK
-        patchelf --set-rpath '$ORIGIN/../../../../../bin:$ORIGIN/../../../../../lib64:$ORIGIN/../../../../../../lib64:$ORIGIN/../../../..:$ORIGIN/../../../../../../lib:$ORIGIN/../../../libfakeroot:$ORIGIN/../../../../../local/lib:$ORIGIN/../../../../../local/lib/x86_64-linux-gnu:$ORIGIN/../../../../../../lib/x86_64-linux-gnu:$ORIGIN/../../..:$ORIGIN/../../../../../../lib32:$ORIGIN/../../../../../lib32:$ORIGIN/../../../../../../lib/x86_64-linux-gnu/gconv:$ORIGIN/.:$ORIGIN/../iconengines:$ORIGIN/../imageformats:$ORIGIN/../xcbglintegrations' ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/platformthemes/* ./AppDir/usr/lib/x86_64-linux-gnu/qt6/plugins/styles/* ./AppDir/lib/x86_64-linux-gnu/libqt6ct*
-
-        ./appimagetool-static.AppImage AppDir
-
     - name: Upload AppImage
       uses: actions/upload-artifact@v4
       with:

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -12,7 +12,7 @@ LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bi
 VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)-anylinux"
 
 # Prepare AppDir
-mkdir ./AppDir/shared/bin
+mkdir -p ./AppDir/shared/bin
 cp -v ./dist/QDiskInfo.desktop      ./AppDir
 cp -v ./dist/QDiskInfo-256x256.png  ./AppDir/QDiskInfo.png
 cp -v ./dist/QDiskInfo-256x256.png  ./AppDir/.DirIcon

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -38,7 +38,7 @@ CURRENTDIR="$(dirname "$(readlink -f "$0")")"
 [ -f "$APPIMAGE".stylesheet ] && APPIMAGE_QT_THEME="$APPIMAGE.stylesheet"
 [ -f "$APPIMAGE_QT_THEME" ] && set -- "$@" "-stylesheet" "$APPIMAGE_QT_THEME"
 exec "$CURRENTDIR"/bin/QDiskInfo "$@"' > ./AppRun
-chmod +x
+chmod +x ./AppRun
 ./sharun -g
 
 # Make AppImage with uruntime

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -32,11 +32,24 @@ chmod +x ./lib4bin
 	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/xcbglintegrations/* \
 	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/wayland-*/*
 
+# also use lib4bin to make a portable smartctl with wrappe 
+./lib4bin --with-wrappe "$(command -v smartctl)"  
+
 # prepare sharun
 echo '#!/bin/sh
 CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 [ -f "$APPIMAGE".stylesheet ] && APPIMAGE_QT_THEME="$APPIMAGE.stylesheet"
 [ -f "$APPIMAGE_QT_THEME" ] && set -- "$@" "-stylesheet" "$APPIMAGE_QT_THEME"
+
+if ! command -v smartctl >/dev/null 2>&1; then
+	echo "smartctl is not on the system, using bundled binary..."
+	export PATH="$PATH:"$CACHEDIR"/qdiskinfo-appimage"
+	mkdir -p "$CACHEDIR"/qdiskinfo-appimage
+	cp -v "$CURRENTDIR"/smartctl "$CACHEDIR"/qdiskinfo-appimage
+	chmod +x "$CACHEDIR"/qdiskinfo-appimage/smartctl
+fi
+
 exec "$CURRENTDIR"/bin/QDiskInfo "$@"' > ./AppRun
 chmod +x ./AppRun
 ./sharun -g

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -51,9 +51,3 @@ chmod +x ./appimagetool
 	--mksquashfs-opt 22 \
 	--no-appstream -u "$UPINFO" \
 	"$PWD"/AppDir "$PWD"/"$APP"-"$VERSION"-"$ARCH".AppImage
-
-
-
-
-
-

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -21,6 +21,7 @@ cd ./AppDir
 
 # ADD LIBRARIES
 wget "$LIB4BN" -O ./lib4bin
+chmod +x ./lib4bin
 ./lib4bin -p -v -s -k  \
 	./shared/bin/QDiskInfo \
 	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/iconengines/* \

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -eu
+
+export ARCH="$(uname -m)"
+export APPIMAGE_EXTRACT_AND_RUN=1
+
+APP=QDiskInfo
+APPIMAGETOOL="https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-$ARCH.AppImage"
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*-$ARCH.AppImage.zsync"
+LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
+VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)-anylinux"
+
+# Prepare AppDir
+mkdir ./AppDir/shared/bin
+cp -v ./dist/QDiskInfo.desktop      ./AppDir
+cp -v ./dist/QDiskInfo-256x256.png  ./AppDir/QDiskInfo.png
+cp -v ./dist/QDiskInfo-256x256.png  ./AppDir/.DirIcon
+cp -v ./build/QDiskInfo             ./AppDir/shared/bin
+cd ./AppDir
+
+# ADD LIBRARIES
+wget "$LIB4BN" -O ./lib4bin
+./lib4bin -p -v -s -k  \
+	./shared/bin/QDiskInfo \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/iconengines/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/imageformats/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/platforms/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/platformthemes/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/styles/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/xcbglintegrations/* \
+	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/wayland-*/*
+
+# prepare sharun
+echo '#!/bin/sh
+CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+[ -f "$APPIMAGE".stylesheet ] && APPIMAGE_QT_THEME="$APPIMAGE.stylesheet"
+[ -f "$APPIMAGE_QT_THEME" ] && set -- "$@" "-stylesheet" "$APPIMAGE_QT_THEME"
+exec "$CURRENTDIR"/bin/QDiskInfo "$@"' > ./AppRun
+chmod +x
+./sharun -g
+
+# Make AppImage with uruntime
+cd ..
+wget "$APPIMAGETOOL" -O ./appimagetool
+chmod +x ./appimagetool
+
+./appimagetool --comp zstd \
+	--mksquashfs-opt -Xcompression-level \
+	--mksquashfs-opt 22 \
+	--no-appstream -u "$UPINFO" \
+	"$PWD"/AppDir "$PWD"/"$APP"-"$VERSION"-"$ARCH".AppImage
+
+
+
+
+
+


### PR DESCRIPTION
fixes #5  

[sharun](https://github.com/VHSgunzo/sharun) has gotten quite a lot better recently and quite a few projects are now using it. 

No more hacks with patchelf are needed to get themes to work, it is able to directly bundle the Qt plugins I tell it to. 

Also I switched the appimagetool to [a fork](https://github.com/pkgforge-dev/appimagetool-uruntime) we have that uses a better runtime by default, the big one being that the appimage **can work by default without fuse at all**

I also added the ability to load external stylesheets in the `AppRun`

![image](https://github.com/user-attachments/assets/7a88a3ee-051e-4135-ac75-3302272980a8)

The `AppRun` loads them if you either place the file next to the AppImage with the name of the AppImage + `.stylesheet` or directly set the env variable `APPIMAGE_QT_THEME` to it.

It also has working theming thru qt6ct: 

![image](https://github.com/user-attachments/assets/49a39df7-2356-465a-9765-885a33a9e2be)

[Artifact for testing](https://github.com/Samueru-sama/QDiskInfo/actions/runs/14214795182)


~~The remaining thing is adding the hook in the `AppRun` to download `smartctl` on the fly when it isn't installed on the host, I can request a static `smartctl` to be added to [soarpkgs ](https://github.com/pkgforge/soarpkgs) that we can pull from.~~

