### PR TITLE
add `Breeze` theme and add `aarch64` builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,24 +12,27 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    container: ghcr.io/pkgforge-dev/archlinux:latest
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y \
-          libgl1-mesa-dev   \
-          libvulkan-dev     \
-          libxkbcommon-dev  \
-          patchelf          \
-          qmake6            \
-          qt6-base-dev      \
-          qt6ct             \
-          qt6-svg-dev       \
-          qt6-tools-dev     \
-          smartmontools     \
+        pacman -Syu --noconfirm \
+          base-devel     \
+          breeze         \
+          clang          \
+          cmake          \
+          libxkbcommon   \
+          mesa           \
+          patchelf       \
+          qt6-base       \
+          qt6ct          \
+          qt6-svg        \
+          qt6-tools      \
+          smartmontools  \
+          vulkan-devel   \
           wget
 
     - name: Build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,56 +3,70 @@ name: Build
 on:
   push:
     branches:
-    - main
+      - main
     paths-ignore:
-    - '**.md'
+      - "**.md"
   pull_request:
   workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
-    container: ghcr.io/pkgforge-dev/archlinux:latest
+    permissions:
+      actions: read
+      security-events: write
+      contents: write
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+          - arch: x86_64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/pkgforge-dev/archlinux:latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        pacman -Syu --noconfirm \
-          base-devel     \
-          breeze         \
-          clang          \
-          cmake          \
-          libxkbcommon   \
-          mesa           \
-          patchelf       \
-          qt6-base       \
-          qt6ct          \
-          qt6-svg        \
-          qt6-tools      \
-          smartmontools  \
-          vulkan-devel   \
-          wget
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm \
+            base-devel     \
+            breeze         \
+            clang          \
+            cmake          \
+            libxkbcommon   \
+            mesa           \
+            patchelf       \
+            qt6-base       \
+            qt6ct          \
+            qt6-svg        \
+            qt6-tools      \
+            smartmontools  \
+            vulkan-devel   \
+            wget
 
-    - name: Build
-      run: |
-        cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=MinSizeRel -DQT_VERSION_MAJOR=6 -DENABLE_TRANSLATIONS=ON
-        cmake --build build
+      - name: Build
+        run: |
+          cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=MinSizeRel -DQT_VERSION_MAJOR=6 -DENABLE_TRANSLATIONS=ON
+          cmake --build build
 
-    - name: Package AppImage
-      run: |
-        chmod +x ./qdiskinfo-appimage.sh
-        ./qdiskinfo-appimage.sh
-        
-    - name: Upload AppImage
-      uses: actions/upload-artifact@v4
-      with:
-        name: QDiskInfo-anylinux-AppImage
-        path: ./QDiskInfo*.AppImage
+      - name: Package AppImage
+        run: |
+          chmod +x ./qdiskinfo-appimage.sh
+          ./qdiskinfo-appimage.sh
 
-    - name: Upload Binaries
-      uses: actions/upload-artifact@v4
-      with:
-        name: QDiskInfo-Qt6-bin
-        path: ./build/QDiskInfo
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: QDiskInfo-${{ matrix.arch }}-AppImage
+          path: ./QDiskInfo*.AppImage
+
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: QDiskInfo-Qt6-${{ matrix.arch }}-bin
+          path: ./build/QDiskInfo

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -11,6 +11,17 @@ UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*-$AR
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 VERSION="$(echo "$GITHUB_SHA" | cut -c 1-9)-anylinux"
 
+# Get iculess qt6-base, removes a 30 MiB lib from the appimage
+if [ "$ARCH" = 'x86_64' ]; then
+	PKG_TYPE='x86_64.pkg.tar.zst'
+else
+	PKG_TYPE='aarch64.pkg.tar.xz'
+fi
+QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-$PKG_TYPE"
+wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
+pacman -U --noconfirm ./qt6-base-iculess.pkg.tar.zst
+rm -f ./qt6-base-iculess.pkg.tar.zst
+
 # Prepare AppDir
 mkdir -p ./AppDir/shared/bin
 cp -v ./dist/QDiskInfo.desktop      ./AppDir
@@ -24,16 +35,16 @@ wget "$LIB4BN" -O ./lib4bin
 chmod +x ./lib4bin
 ./lib4bin -p -v -s -k  \
 	./shared/bin/QDiskInfo \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/iconengines/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/imageformats/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/platforms/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/platformthemes/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/styles/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/xcbglintegrations/* \
-	/usr/lib/"$ARCH"-linux-gnu/qt6/plugins/wayland-*/*
+	/usr/lib/qt6/plugins/iconengines/* \
+	/usr/lib/qt6/plugins/imageformats/* \
+	/usr/lib/qt6/plugins/platforms/* \
+	/usr/lib/qt6/plugins/platformthemes/* \
+	/usr/lib/qt6/plugins/styles/* \
+	/usr/lib/qt6/plugins/xcbglintegrations/* \
+	/usr/lib/qt6/plugins/wayland-*/*
 
 # also use lib4bin to make a portable smartctl with wrappe 
-./lib4bin --with-wrappe "$(command -v smartctl)"  
+./lib4bin -s --with-wrappe "$(command -v smartctl)"  
 
 # prepare sharun
 echo '#!/bin/sh

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -51,6 +51,7 @@ chmod +x ./lib4bin
 echo '#!/bin/sh
 CURRENTDIR="$(dirname "$(readlink -f "$0")")"
 CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+export QT_STYLE_OVERRIDE=${QT_STYLE_OVERRIDE:-Breeze}
 [ -f "$APPIMAGE".stylesheet ] && APPIMAGE_QT_THEME="$APPIMAGE.stylesheet"
 [ -f "$APPIMAGE_QT_THEME" ] && set -- "$@" "-stylesheet" "$APPIMAGE_QT_THEME"
 

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -4,6 +4,7 @@ set -eu
 
 export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
+export QT_STYLE_OVERRIDE=Breeze # Make sure the breeze theme is dlopened
 
 APP=QDiskInfo
 APPIMAGETOOL="https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-$ARCH.AppImage"

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -51,7 +51,7 @@ chmod +x ./lib4bin
 echo '#!/bin/sh
 CURRENTDIR="$(dirname "$(readlink -f "$0")")"
 CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
-export QT_STYLE_OVERRIDE=${QT_STYLE_OVERRIDE:-Breeze}
+export QT_STYLE_OVERRIDE="${QT_STYLE_OVERRIDE:-Breeze}"
 [ -f "$APPIMAGE".stylesheet ] && APPIMAGE_QT_THEME="$APPIMAGE.stylesheet"
 [ -f "$APPIMAGE_QT_THEME" ] && set -- "$@" "-stylesheet" "$APPIMAGE_QT_THEME"
 

--- a/qdiskinfo-appimage.sh
+++ b/qdiskinfo-appimage.sh
@@ -71,8 +71,5 @@ cd ..
 wget "$APPIMAGETOOL" -O ./appimagetool
 chmod +x ./appimagetool
 
-./appimagetool --comp zstd \
-	--mksquashfs-opt -Xcompression-level \
-	--mksquashfs-opt 22 \
-	--no-appstream -u "$UPINFO" \
+./appimagetool --no-appstream -u "$UPINFO" \
 	"$PWD"/AppDir "$PWD"/"$APP"-"$VERSION"-"$ARCH".AppImage


### PR DESCRIPTION
We had to migrate to archlinux to bundle the theme, the good news is that the AppImage is now smaller at 43.4 MIB. 

Also @psadi added aarch64 builds 💪

Fixes #39 

![image](https://github.com/user-attachments/assets/1d25e1ba-7740-46f0-a4c6-84469302f345)
