### PR TITLE
upload `.zsync` file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: QDiskInfo-${{ matrix.arch }}-AppImage
-          path: ./QDiskInfo*.AppImage
+          path: ./QDiskInfo*.AppImage*
 
       - name: Upload Binaries
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Response to https://github.com/edisionnano/QDiskInfo/issues/42#issuecomment-2803243595

The file was already being made, just that it wasn't being uploaded.

![image](https://github.com/user-attachments/assets/be67893b-d7ab-4157-91f7-719998d33b59)

these two have to be released together for delta updates to work. 

Note that they cannot be renamed before being released otherwise it breaks. 