### PR TITLE
Add option to change Power on Hours to Power on Time

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -40,6 +40,7 @@ private slots:
     void on_actionIgnore_C4_Reallocation_Event_Count_toggled(bool enabled);
     void on_actionHEX_toggled(bool enabled);
     void on_actionUse_Fahrenheit_toggled(bool enabled);
+    void on_actionUse_Human_Readable_Time_toggled(bool enabled);
     void on_actionCyclic_Navigation_toggled(bool arg1);
     void on_actionUse_GB_instead_of_TB_toggled(bool arg1);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -103,6 +103,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->actionIgnore_C4_Reallocation_Event_Count->setChecked(settings.value("IgnoreC4", true).toBool());
     ui->actionHEX->setChecked(settings.value("HEX", true).toBool());
     ui->actionUse_Fahrenheit->setChecked(settings.value("Fahrenheit", false).toBool());
+    ui->actionUse_Fahrenheit->setChecked(settings.value("HumanReadableTime", false).toBool());
     ui->actionCyclic_Navigation->setChecked(settings.value("CyclicNavigation", false).toBool());
     ui->actionUse_GB_instead_of_TB->setChecked(settings.value("UseGB", false).toBool());
 
@@ -448,6 +449,7 @@ void MainWindow::populateWindow(const QJsonObject &localObj, const QString &heal
     int64_t totalMbWritesI64 = 0;
     int64_t totalMbReadsI64 = 0;
     bool useGB = ui->actionUse_GB_instead_of_TB->isChecked();
+    bool useHumanReadableTime = ui->actionUse_Human_Readable_Time->isChecked();
 
     QString diskCapacityString = getMbToPrettyString(diskCapacityMbI64, PRECISION_CAPACITY_TO_STR, useGB);
 
@@ -493,7 +495,7 @@ void MainWindow::populateWindow(const QJsonObject &localObj, const QString &heal
         selfTestsTableWidget->setRowCount(static_cast<int>(rowCount));
         selfTestsTableWidget->setColumnCount(3);
         selfTestsTableWidget->verticalHeader()->setVisible(false);
-        selfTestsTableWidget->setHorizontalHeaderLabels({tr("Type"), tr("Status"), tr("Power On Hours")});
+        selfTestsTableWidget->setHorizontalHeaderLabels({tr("Type"), tr("Status"), tr("Power On Time")});
 
         for (int i = 0; i < rowCount; ++i) {
             QJsonObject entry = selfTestsTable[i].toObject();
@@ -583,7 +585,11 @@ void MainWindow::populateWindow(const QJsonObject &localObj, const QString &heal
     int powerOnTimeInt = localObj["power_on_time"].toObject().value("hours").toInt(-1);
     QString powerOnTime;
     if (powerOnTimeInt >= 0) {
-        powerOnTime = QString::number(powerOnTimeInt) + " " + tr("hours");
+        if (useHumanReadableTime) {
+            powerOnTime = QString::number(powerOnTimeInt / 24 / 365) + " " + tr("years") + " " + QString::number(powerOnTimeInt / 24 % 365) + " " + tr("days") + " " + QString::number(powerOnTimeInt % 24) + " " + tr("hours");
+        } else {
+            powerOnTime = QString::number(powerOnTimeInt) + " " + tr("hours");
+        }
     } else {
         powerOnTime = "Unknown";
     }
@@ -1391,6 +1397,14 @@ void MainWindow::on_actionUse_Fahrenheit_toggled(bool enabled)
     }
 }
 
+void MainWindow::on_actionUse_Human_Readable_Time_toggled(bool enabled)
+{
+    settings.setValue("HumanReadableTime", enabled);
+    if (!initializing) {
+        updateUI(Utils.clearButtonGroup(buttonGroup, horizontalLayout, buttonStretch, menuDisk));
+    }
+}
+
 void MainWindow::on_actionCyclic_Navigation_toggled(bool cyclicNavigation)
 {
     settings.setValue("CyclicNavigation", cyclicNavigation);
@@ -1423,12 +1437,14 @@ void MainWindow::on_actionClear_Settings_triggered()
         settings.setValue("IgnoreC4", true);
         settings.setValue("HEX", true);
         settings.setValue("Fahrenheit", false);
+        settings.setValue("HumanReadableTime", false);
         settings.setValue("CyclicNavigation", false);
         settings.setValue("UseGB", false);
 
         ui->actionIgnore_C4_Reallocation_Event_Count->setChecked(true);
         ui->actionHEX->setChecked(true);
         ui->actionUse_Fahrenheit->setChecked(false);
+        ui->actionUse_Human_Readable_Time->setChecked(false);
         ui->actionCyclic_Navigation->setChecked(false);
         ui->actionUse_GB_instead_of_TB->setChecked(false);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -325,7 +325,7 @@
             <item row="4" column="0">
              <widget class="QLabel" name="powerOnHoursLabel">
               <property name="text">
-               <string>Power On Hours</string>
+               <string>Power On Time</string>
               </property>
              </widget>
             </item>
@@ -508,6 +508,7 @@
     <addaction name="actionIgnore_C4_Reallocation_Event_Count"/>
     <addaction name="actionHEX"/>
     <addaction name="actionUse_Fahrenheit"/>
+    <addaction name="actionUse_Human_Readable_Time"/>
     <addaction name="actionCyclic_Navigation"/>
     <addaction name="actionUse_GB_instead_of_TB"/>
     <addaction name="separator"/>
@@ -616,6 +617,14 @@
    </property>
    <property name="text">
     <string>&amp;Use Fahrenheit</string>
+   </property>
+  </action>
+  <action name="actionUse_Human_Readable_Time">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Use Human Readable Time</string>
    </property>
   </action>
   <action name="actionSelf_Test">

--- a/translations/qdiskinfo_af_ZA.ts
+++ b/translations/qdiskinfo_af_ZA.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ar_SA.ts
+++ b/translations/qdiskinfo_ar_SA.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ca_ES.ts
+++ b/translations/qdiskinfo_ca_ES.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_cs_CZ.ts
+++ b/translations/qdiskinfo_cs_CZ.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_da_DK.ts
+++ b/translations/qdiskinfo_da_DK.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_de_DE.ts
+++ b/translations/qdiskinfo_de_DE.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_de_DE.ts
+++ b/translations/qdiskinfo_de_DE.ts
@@ -75,8 +75,8 @@
         <translation>Anzahl der Einschaltungen</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Betriebsstunden</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Fahrenheit benutzen</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>Stunden</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_el_GR.ts
+++ b/translations/qdiskinfo_el_GR.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_el_GR.ts
+++ b/translations/qdiskinfo_el_GR.ts
@@ -75,8 +75,8 @@
         <translation>Μετρητής Λειτουργίας</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Ώρες Λειτουργίας</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>Χρήση &amp;Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>ώρες</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_en_US.ts
+++ b/translations/qdiskinfo_en_US.ts
@@ -75,7 +75,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Power On Hours</source>
+        <source>Power On Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -128,6 +128,10 @@
     </message>
     <message>
         <source>&amp;Use Fahrenheit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -188,6 +192,14 @@
     </message>
     <message>
         <source>hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>years</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/qdiskinfo_es_ES.ts
+++ b/translations/qdiskinfo_es_ES.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_es_ES.ts
+++ b/translations/qdiskinfo_es_ES.ts
@@ -75,8 +75,8 @@
         <translation>Veces Encendido</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Horas Encendido</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Usar Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>horas</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_fi_FI.ts
+++ b/translations/qdiskinfo_fi_FI.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_fr_FR.ts
+++ b/translations/qdiskinfo_fr_FR.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_he_IL.ts
+++ b/translations/qdiskinfo_he_IL.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_hu_HU.ts
+++ b/translations/qdiskinfo_hu_HU.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_it_IT.ts
+++ b/translations/qdiskinfo_it_IT.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_it_IT.ts
+++ b/translations/qdiskinfo_it_IT.ts
@@ -1,445 +1,457 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS sourcelanguage="en" version="2.1" language="it_IT">
-    <context>
-        <name>GridView</name>
-        <message>
-            <source>Grid View</source>
-            <translation>Vista griglia</translation>
-        </message>
-        <message>
-            <source>Search for a disk...</source>
-            <translation>Cerca un disco...</translation>
-        </message>
-    </context>
-    <context>
-        <name>MainWindow</name>
-        <message>
-            <source>QDiskInfo</source>
-            <translation>QDiskInfo</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Health Status&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Stato di salute&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Good&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Buono&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Temperature&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Temperatura&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;23° C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;23° C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>Firmware</source>
-            <translation>Firmware</translation>
-        </message>
-        <message>
-            <source>Serial Number</source>
-            <translation>Numero di serie</translation>
-        </message>
-        <message>
-            <source>Protocol</source>
-            <translation>Protocollo</translation>
-        </message>
-        <message>
-            <source>Device Node</source>
-            <translation>Nodo dispositivo</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Good 100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Buono 100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>Type</source>
-            <translation>Tipo</translation>
-        </message>
-        <message>
-            <source>Total Host Reads</source>
-            <translation>Totale letture host</translation>
-        </message>
-        <message>
-            <source>Total Host Writes</source>
-            <translation>Totale scritture host</translation>
-        </message>
-        <message>
-            <source>Rotation Rate</source>
-            <translation>Tasso di rotazione</translation>
-        </message>
-        <message>
-            <source>Power On Count</source>
-            <translation>Conteggio accensioni</translation>
-        </message>
-        <message>
-            <source>Power On Hours</source>
-            <translation>Ore funzionamento</translation>
-        </message>
-        <message>
-            <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-            <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Nome disco&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-        </message>
-        <message>
-            <source>File</source>
-            <translation>File</translation>
-        </message>
-        <message>
-            <source>Settings</source>
-            <translation>Impostazioni</translation>
-        </message>
-        <message>
-            <source>&amp;Help</source>
-            <translation>&amp;Aiuto</translation>
-        </message>
-        <message>
-            <source>De&amp;vice</source>
-            <translation>Dispositi&amp;vo</translation>
-        </message>
-        <message>
-            <source>Disk</source>
-            <translation>Disco</translation>
-        </message>
-        <message>
-            <source>&amp;Quit</source>
-            <translation>&amp;Esci</translation>
-        </message>
-        <message>
-            <source>&amp;Refresh Devices</source>
-            <translation>Aggio&amp;rna dispositivi</translation>
-        </message>
-        <message>
-            <source>&amp;GitHub</source>
-            <translation>&amp;GitHub</translation>
-        </message>
-        <message>
-            <source>&amp;About QDiskInfo</source>
-            <translation>&amp;Info su QDiskInfo</translation>
-        </message>
-        <message>
-            <source>&amp;Ignore C4 (Reallocated Event Count)</source>
-            <translation>&amp;Ignora C4 (conteggio eventi di riallocazione)</translation>
-        </message>
-        <message>
-            <source>&amp;Convert Raw values to HEX</source>
-            <translation>&amp;Converti valori grezzi in HEX</translation>
-        </message>
-        <message>
-            <source>&amp;Use Fahrenheit</source>
-            <translation>&amp;Usa i Fahrenheit</translation>
-        </message>
-        <message>
-            <source>Self Test</source>
-            <translation>Autotest</translation>
-        </message>
-        <message>
-            <source>Cyclic &amp;Navigation</source>
-            <translation>&amp;Navigazione Ciclica</translation>
-        </message>
-        <message>
-            <source>Use &amp;GB instead of TB</source>
-            <translation>Usa &amp;GB invece di TB</translation>
-        </message>
-        <message>
-            <source>About &amp;Qt</source>
-            <translation>Info su &amp;Qt</translation>
-        </message>
-        <message>
-            <source>Start Self Test</source>
-            <translation>Avvia autotest</translation>
-        </message>
-        <message>
-            <source>Self Test Log</source>
-            <translation>Registro autotest</translation>
-        </message>
-        <message>
-            <source>Critical Warning</source>
-            <translation>Avviso critico</translation>
-        </message>
-        <message>
-            <source>Grown Defect List</source>
-            <translation>Elenco aumento difetti</translation>
-        </message>
-        <message>
-            <source>Good</source>
-            <translation>Buono</translation>
-        </message>
-        <message>
-            <source>Caution</source>
-            <translation>Attenzione</translation>
-        </message>
-        <message>
-            <source>Bad</source>
-            <translation>Cattivo</translation>
-        </message>
-        <message>
-            <source>Unknown</source>
-            <translation>Sconosciuto</translation>
-        </message>
-        <message>
-            <source>Status</source>
-            <translation>Stato</translation>
-        </message>
-        <message>
-            <source>count</source>
-            <translation>conteggio</translation>
-        </message>
-        <message>
-            <source>hours</source>
-            <translation>ore</translation>
-        </message>
-        <message>
-            <source>Short</source>
-            <translation>Breve</translation>
-        </message>
-        <message>
-            <source>Conveyance</source>
-            <translation>Trasporto</translation>
-        </message>
-        <message>
-            <source>Extended</source>
-            <translation>Esteso</translation>
-        </message>
-        <message>
-            <source>Min.)</source>
-            <translation>Min.)</translation>
-        </message>
-        <message>
-            <source>Read</source>
-            <translation>Lettura</translation>
-        </message>
-        <message>
-            <source>Write</source>
-            <translation>Scrittura</translation>
-        </message>
-        <message>
-            <source>Verify</source>
-            <translation>Verifica</translation>
-        </message>
-        <message>
-            <source>ID</source>
-            <translation>ID</translation>
-        </message>
-        <message>
-            <source>Attribute Name</source>
-            <translation>Nome attributo</translation>
-        </message>
-        <message>
-            <source>Raw Values</source>
-            <translation>Valori grezzi</translation>
-        </message>
-        <message>
-            <source>Available spare capacity has fallen below the threshold</source>
-            <translation>Lo spazio inutilizzato disponibile è sceso al di sotto della soglia</translation>
-        </message>
-        <message>
-            <source>Temperature error (Overheat or Overcool)</source>
-            <translation>Errore di temperatura (surriscaldamento o sovraraffreddamento)</translation>
-        </message>
-        <message>
-            <source>NVM subsystem reliability has been degraded</source>
-            <translation>L&apos;affidabilità del sottosistema NVM è diminuita</translation>
-        </message>
-        <message>
-            <source>Media has been placed in Read Only Mode</source>
-            <translation>Il supporto è stato posto in modalità sola lettura</translation>
-        </message>
-        <message>
-            <source>Volatile memory backup device has Failed</source>
-            <translation>Il dispositivo di backup della memoria volatile ha fallito</translation>
-        </message>
-        <message>
-            <source>Persistent memory region has become Read-Only</source>
-            <translation>La regione della memoria persistente è diventata di sola lettura</translation>
-        </message>
-        <message>
-            <source>Current</source>
-            <translation>Corrente</translation>
-        </message>
-        <message>
-            <source>Worst</source>
-            <translation>Peggiore</translation>
-        </message>
-        <message>
-            <source>Threshold</source>
-            <translation>Soglia</translation>
-        </message>
-        <message>
-            <source>Empty JSON</source>
-            <translation>JSON vuoto</translation>
-        </message>
-        <message>
-            <source>The JSON is empty</source>
-            <translation>Il JSON è vuoto</translation>
-        </message>
-        <message>
-            <source>Save JSON</source>
-            <translation>Salva JSON</translation>
-        </message>
-        <message>
-            <source>JSON (*.json);;All Files (*)</source>
-            <translation>JSON (*.json);;Tutti i file (*)</translation>
-        </message>
-        <message>
-            <source>Unable to open file for writing</source>
-            <translation>Impossibile aprire il file in scrittura</translation>
-        </message>
-        <message>
-            <source>An ATA and NVMe S.M.A.R.T. data viewer for Linux</source>
-            <translation>Un visualizzatore dati S.M.A.R.T. ATA e NVMe per Linux</translation>
-        </message>
-        <message>
-            <source>Licensed under the GNU G.P.L. Version 3</source>
-            <translation>Rilasciato con licenza GNU G.P.L. Versione 3</translation>
-        </message>
-        <message>
-            <source>Made by Samantas5855</source>
-            <translation>Realizzato da Samantas5855</translation>
-        </message>
-        <message>
-            <source>Version</source>
-            <translation>Versione</translation>
-        </message>
-        <message>
-            <source>About QDiskInfo</source>
-            <translation>Informazioni su QDiskInfo</translation>
-        </message>
-        <message>
-            <source>About Qt</source>
-            <translation>Info su Qt</translation>
-        </message>
-        <message>
-            <source>Clear &amp;Settings</source>
-            <translation>Cancella impo&amp;stazioni</translation>
-        </message>
-        <message>
-            <source>ASCII View</source>
-            <translation>Vista ASCII</translation>
-        </message>
-        <message>
-            <source>QDiskInfo Error</source>
-            <translation>Errore QDiskInfo</translation>
-        </message>
-        <message>
-            <source>QDiskInfo needs root access in order to read S.M.A.R.T. data!</source>
-            <translation>QDiskInfo ha bisogno di accesso root per leggere i dati S.M.A.R.T!</translation>
-        </message>
-        <message>
-            <source>Save Binary Data</source>
-            <translation>Salva dati binari</translation>
-        </message>
-        <message>
-            <source>Binary Files (*.bin);;All Files (*)</source>
-            <translation>File binari (*.bin);;Tutti i file (*)</translation>
-        </message>
-        <message>
-            <source>Success</source>
-            <translation>Successo</translation>
-        </message>
-        <message>
-            <source>Binary data saved successfully.</source>
-            <translation>Dati binari salvati.</translation>
-        </message>
-        <message>
-            <source>&amp;Save (JSON)</source>
-            <translation>&amp;Salva (JSON)</translation>
-        </message>
-        <message>
-            <source>Ctrl+T</source>
-            <translation type="unfinished">Ctrl+T</translation>
-        </message>
-        <message>
-            <source>Grid View</source>
-            <translation>Vista griglia</translation>
-        </message>
-        <message>
-            <source>Save (Image)</source>
-            <translation>Salva (Immagine)</translation>
-        </message>
-        <message>
-            <source>Save Image</source>
-            <translation>Salva immagine</translation>
-        </message>
-        <message>
-            <source>PNG Files (*.png)</source>
-            <translation>File PNG (*.png)</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <source>QDiskInfo Error</source>
-            <translation>Errore QDiskInfo</translation>
-        </message>
-        <message>
-            <source>QDiskInfo needs root access in order to read S.M.A.R.T. data!</source>
-            <translation>QDiskInfo ha bisogno di accesso root per leggere i dati S.M.A.R.T!</translation>
-        </message>
-        <message>
-            <source>smartctl was not found, please install it!</source>
-            <translation>smartctl non è stato trovato, è necessario installarlo!</translation>
-        </message>
-        <message>
-            <source>QDiskInfo needs root access in order to abort a self-test!</source>
-            <translation>QDiskInfo ha bisogno di accesso root per interrompere un autotest!</translation>
-        </message>
-        <message>
-            <source>Test Requested</source>
-            <translation>Test richiesto</translation>
-        </message>
-        <message>
-            <source>The self-test has been aborted</source>
-            <translation>L&apos;autotest è stato interrotto</translation>
-        </message>
-        <message>
-            <source>Error: Something went wrong</source>
-            <translation>Errore: qualcosa è andato storto</translation>
-        </message>
-        <message>
-            <source>QDiskInfo needs root access in order to request a self-test!</source>
-            <translation>QDiskInfo ha bisogno di accesso root per richiedere un autotest!</translation>
-        </message>
-        <message>
-            <source>remaining</source>
-            <translation>rimanenti</translation>
-        </message>
-        <message>
-            <source>completed</source>
-            <translation>completato</translation>
-        </message>
-        <message>
-            <source>Test Already Running</source>
-            <translation>Test già in esecuzione</translation>
-        </message>
-        <message>
-            <source>A self-test is already being performed</source>
-            <translation>Si sta già effettuando un autotest</translation>
-        </message>
-        <message>
-            <source>You can press the Ok button in order to abort the test that is currently running</source>
-            <translation>Premere il pulsante Ok per interrompere il test attualmente in esecuzione</translation>
-        </message>
-        <message>
-            <source>A self-test has been requested successfully</source>
-            <translation>Un autotest è stato richiesto con successo</translation>
-        </message>
-        <message>
-            <source>It will be completed after</source>
-            <translation>Sarà completato dopo</translation>
-        </message>
-        <message>
-            <source>minutes</source>
-            <translation>minuti</translation>
-        </message>
-        <message>
-            <source>Clear Settings</source>
-            <translation>Cancella impostazioni</translation>
-        </message>
-        <message>
-            <source>Are you sure you want to clear the settings saved on disk?</source>
-            <translation>Sicuri di voler cancellare le impostazioni salvate su disco?</translation>
-        </message>
-    </context>
+<TS version="2.1" language="it_IT" sourcelanguage="en">
+<context>
+    <name>GridView</name>
+    <message>
+        <source>Grid View</source>
+        <translation>Vista griglia</translation>
+    </message>
+    <message>
+        <source>Search for a disk...</source>
+        <translation>Cerca un disco...</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>QDiskInfo</source>
+        <translation>QDiskInfo</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Health Status&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Stato di salute&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Good&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Buono&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Temperature&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Temperatura&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;23° C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;23° C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <source>Serial Number</source>
+        <translation>Numero di serie</translation>
+    </message>
+    <message>
+        <source>Protocol</source>
+        <translation>Protocollo</translation>
+    </message>
+    <message>
+        <source>Device Node</source>
+        <translation>Nodo dispositivo</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Good 100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:700; color:#000000;&quot;&gt;Buono 100 %&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Total Host Reads</source>
+        <translation>Totale letture host</translation>
+    </message>
+    <message>
+        <source>Total Host Writes</source>
+        <translation>Totale scritture host</translation>
+    </message>
+    <message>
+        <source>Rotation Rate</source>
+        <translation>Tasso di rotazione</translation>
+    </message>
+    <message>
+        <source>Power On Count</source>
+        <translation>Conteggio accensioni</translation>
+    </message>
+    <message>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Nome disco&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>File</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Aiuto</translation>
+    </message>
+    <message>
+        <source>De&amp;vice</source>
+        <translation>Dispositi&amp;vo</translation>
+    </message>
+    <message>
+        <source>Disk</source>
+        <translation>Disco</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>&amp;Esci</translation>
+    </message>
+    <message>
+        <source>&amp;Refresh Devices</source>
+        <translation>Aggio&amp;rna dispositivi</translation>
+    </message>
+    <message>
+        <source>&amp;GitHub</source>
+        <translation>&amp;GitHub</translation>
+    </message>
+    <message>
+        <source>&amp;About QDiskInfo</source>
+        <translation>&amp;Info su QDiskInfo</translation>
+    </message>
+    <message>
+        <source>&amp;Ignore C4 (Reallocated Event Count)</source>
+        <translation>&amp;Ignora C4 (conteggio eventi di riallocazione)</translation>
+    </message>
+    <message>
+        <source>&amp;Convert Raw values to HEX</source>
+        <translation>&amp;Converti valori grezzi in HEX</translation>
+    </message>
+    <message>
+        <source>&amp;Use Fahrenheit</source>
+        <translation>&amp;Usa i Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Self Test</source>
+        <translation>Autotest</translation>
+    </message>
+    <message>
+        <source>Cyclic &amp;Navigation</source>
+        <translation>&amp;Navigazione Ciclica</translation>
+    </message>
+    <message>
+        <source>Use &amp;GB instead of TB</source>
+        <translation>Usa &amp;GB invece di TB</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>Info su &amp;Qt</translation>
+    </message>
+    <message>
+        <source>Start Self Test</source>
+        <translation>Avvia autotest</translation>
+    </message>
+    <message>
+        <source>Self Test Log</source>
+        <translation>Registro autotest</translation>
+    </message>
+    <message>
+        <source>Critical Warning</source>
+        <translation>Avviso critico</translation>
+    </message>
+    <message>
+        <source>Grown Defect List</source>
+        <translation>Elenco aumento difetti</translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <translation>Buono</translation>
+    </message>
+    <message>
+        <source>Caution</source>
+        <translation>Attenzione</translation>
+    </message>
+    <message>
+        <source>Bad</source>
+        <translation>Cattivo</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Sconosciuto</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+    <message>
+        <source>count</source>
+        <translation>conteggio</translation>
+    </message>
+    <message>
+        <source>hours</source>
+        <translation>ore</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Short</source>
+        <translation>Breve</translation>
+    </message>
+    <message>
+        <source>Conveyance</source>
+        <translation>Trasporto</translation>
+    </message>
+    <message>
+        <source>Extended</source>
+        <translation>Esteso</translation>
+    </message>
+    <message>
+        <source>Min.)</source>
+        <translation>Min.)</translation>
+    </message>
+    <message>
+        <source>Read</source>
+        <translation>Lettura</translation>
+    </message>
+    <message>
+        <source>Write</source>
+        <translation>Scrittura</translation>
+    </message>
+    <message>
+        <source>Verify</source>
+        <translation>Verifica</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Attribute Name</source>
+        <translation>Nome attributo</translation>
+    </message>
+    <message>
+        <source>Raw Values</source>
+        <translation>Valori grezzi</translation>
+    </message>
+    <message>
+        <source>Available spare capacity has fallen below the threshold</source>
+        <translation>Lo spazio inutilizzato disponibile è sceso al di sotto della soglia</translation>
+    </message>
+    <message>
+        <source>Temperature error (Overheat or Overcool)</source>
+        <translation>Errore di temperatura (surriscaldamento o sovraraffreddamento)</translation>
+    </message>
+    <message>
+        <source>NVM subsystem reliability has been degraded</source>
+        <translation>L&apos;affidabilità del sottosistema NVM è diminuita</translation>
+    </message>
+    <message>
+        <source>Media has been placed in Read Only Mode</source>
+        <translation>Il supporto è stato posto in modalità sola lettura</translation>
+    </message>
+    <message>
+        <source>Volatile memory backup device has Failed</source>
+        <translation>Il dispositivo di backup della memoria volatile ha fallito</translation>
+    </message>
+    <message>
+        <source>Persistent memory region has become Read-Only</source>
+        <translation>La regione della memoria persistente è diventata di sola lettura</translation>
+    </message>
+    <message>
+        <source>Current</source>
+        <translation>Corrente</translation>
+    </message>
+    <message>
+        <source>Worst</source>
+        <translation>Peggiore</translation>
+    </message>
+    <message>
+        <source>Threshold</source>
+        <translation>Soglia</translation>
+    </message>
+    <message>
+        <source>Empty JSON</source>
+        <translation>JSON vuoto</translation>
+    </message>
+    <message>
+        <source>The JSON is empty</source>
+        <translation>Il JSON è vuoto</translation>
+    </message>
+    <message>
+        <source>Save JSON</source>
+        <translation>Salva JSON</translation>
+    </message>
+    <message>
+        <source>JSON (*.json);;All Files (*)</source>
+        <translation>JSON (*.json);;Tutti i file (*)</translation>
+    </message>
+    <message>
+        <source>Unable to open file for writing</source>
+        <translation>Impossibile aprire il file in scrittura</translation>
+    </message>
+    <message>
+        <source>An ATA and NVMe S.M.A.R.T. data viewer for Linux</source>
+        <translation>Un visualizzatore dati S.M.A.R.T. ATA e NVMe per Linux</translation>
+    </message>
+    <message>
+        <source>Licensed under the GNU G.P.L. Version 3</source>
+        <translation>Rilasciato con licenza GNU G.P.L. Versione 3</translation>
+    </message>
+    <message>
+        <source>Made by Samantas5855</source>
+        <translation>Realizzato da Samantas5855</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>Versione</translation>
+    </message>
+    <message>
+        <source>About QDiskInfo</source>
+        <translation>Informazioni su QDiskInfo</translation>
+    </message>
+    <message>
+        <source>About Qt</source>
+        <translation>Info su Qt</translation>
+    </message>
+    <message>
+        <source>Clear &amp;Settings</source>
+        <translation>Cancella impo&amp;stazioni</translation>
+    </message>
+    <message>
+        <source>ASCII View</source>
+        <translation>Vista ASCII</translation>
+    </message>
+    <message>
+        <source>QDiskInfo Error</source>
+        <translation>Errore QDiskInfo</translation>
+    </message>
+    <message>
+        <source>QDiskInfo needs root access in order to read S.M.A.R.T. data!</source>
+        <translation>QDiskInfo ha bisogno di accesso root per leggere i dati S.M.A.R.T!</translation>
+    </message>
+    <message>
+        <source>Save Binary Data</source>
+        <translation>Salva dati binari</translation>
+    </message>
+    <message>
+        <source>Binary Files (*.bin);;All Files (*)</source>
+        <translation>File binari (*.bin);;Tutti i file (*)</translation>
+    </message>
+    <message>
+        <source>Success</source>
+        <translation>Successo</translation>
+    </message>
+    <message>
+        <source>Binary data saved successfully.</source>
+        <translation>Dati binari salvati.</translation>
+    </message>
+    <message>
+        <source>&amp;Save (JSON)</source>
+        <translation>&amp;Salva (JSON)</translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished">Ctrl+T</translation>
+    </message>
+    <message>
+        <source>Grid View</source>
+        <translation>Vista griglia</translation>
+    </message>
+    <message>
+        <source>Save (Image)</source>
+        <translation>Salva (Immagine)</translation>
+    </message>
+    <message>
+        <source>Save Image</source>
+        <translation>Salva immagine</translation>
+    </message>
+    <message>
+        <source>PNG Files (*.png)</source>
+        <translation>File PNG (*.png)</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>QDiskInfo Error</source>
+        <translation>Errore QDiskInfo</translation>
+    </message>
+    <message>
+        <source>QDiskInfo needs root access in order to read S.M.A.R.T. data!</source>
+        <translation>QDiskInfo ha bisogno di accesso root per leggere i dati S.M.A.R.T!</translation>
+    </message>
+    <message>
+        <source>smartctl was not found, please install it!</source>
+        <translation>smartctl non è stato trovato, è necessario installarlo!</translation>
+    </message>
+    <message>
+        <source>QDiskInfo needs root access in order to abort a self-test!</source>
+        <translation>QDiskInfo ha bisogno di accesso root per interrompere un autotest!</translation>
+    </message>
+    <message>
+        <source>Test Requested</source>
+        <translation>Test richiesto</translation>
+    </message>
+    <message>
+        <source>The self-test has been aborted</source>
+        <translation>L&apos;autotest è stato interrotto</translation>
+    </message>
+    <message>
+        <source>Error: Something went wrong</source>
+        <translation>Errore: qualcosa è andato storto</translation>
+    </message>
+    <message>
+        <source>QDiskInfo needs root access in order to request a self-test!</source>
+        <translation>QDiskInfo ha bisogno di accesso root per richiedere un autotest!</translation>
+    </message>
+    <message>
+        <source>remaining</source>
+        <translation>rimanenti</translation>
+    </message>
+    <message>
+        <source>completed</source>
+        <translation>completato</translation>
+    </message>
+    <message>
+        <source>Test Already Running</source>
+        <translation>Test già in esecuzione</translation>
+    </message>
+    <message>
+        <source>A self-test is already being performed</source>
+        <translation>Si sta già effettuando un autotest</translation>
+    </message>
+    <message>
+        <source>You can press the Ok button in order to abort the test that is currently running</source>
+        <translation>Premere il pulsante Ok per interrompere il test attualmente in esecuzione</translation>
+    </message>
+    <message>
+        <source>A self-test has been requested successfully</source>
+        <translation>Un autotest è stato richiesto con successo</translation>
+    </message>
+    <message>
+        <source>It will be completed after</source>
+        <translation>Sarà completato dopo</translation>
+    </message>
+    <message>
+        <source>minutes</source>
+        <translation>minuti</translation>
+    </message>
+    <message>
+        <source>Clear Settings</source>
+        <translation>Cancella impostazioni</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear the settings saved on disk?</source>
+        <translation>Sicuri di voler cancellare le impostazioni salvate su disco?</translation>
+    </message>
+</context>
 </TS>

--- a/translations/qdiskinfo_ja_JP.ts
+++ b/translations/qdiskinfo_ja_JP.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_ja_JP.ts
+++ b/translations/qdiskinfo_ja_JP.ts
@@ -75,8 +75,8 @@
         <translation>電源投入回数</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>動作時間</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ko_KR.ts
+++ b/translations/qdiskinfo_ko_KR.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_lv_LV.ts
+++ b/translations/qdiskinfo_lv_LV.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_lv_LV.ts
+++ b/translations/qdiskinfo_lv_LV.ts
@@ -75,8 +75,8 @@
         <translation>Ieslēgšanu skaits</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Darbojies</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Temperatūra Fārenheita grādos</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>stundas</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_nl_NL.ts
+++ b/translations/qdiskinfo_nl_NL.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_no_NO.ts
+++ b/translations/qdiskinfo_no_NO.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_pl_PL.ts
+++ b/translations/qdiskinfo_pl_PL.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_pt_BR.ts
+++ b/translations/qdiskinfo_pt_BR.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_pt_BR.ts
+++ b/translations/qdiskinfo_pt_BR.ts
@@ -75,8 +75,8 @@
         <translation>Nº de Vezes Ligado</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Nº de Horas Ligado</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Usar Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>horas</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_pt_PT.ts
+++ b/translations/qdiskinfo_pt_PT.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ro_RO.ts
+++ b/translations/qdiskinfo_ro_RO.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ru_RU.ts
+++ b/translations/qdiskinfo_ru_RU.ts
@@ -75,8 +75,8 @@
         <translation>Количество включений</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Время работы</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Температура в Фаренгейтах</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>часов</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_ru_RU.ts
+++ b/translations/qdiskinfo_ru_RU.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_sr_SP.ts
+++ b/translations/qdiskinfo_sr_SP.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_sv_SE.ts
+++ b/translations/qdiskinfo_sv_SE.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_th_TH.ts
+++ b/translations/qdiskinfo_th_TH.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_tr_TR.ts
+++ b/translations/qdiskinfo_tr_TR.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_uk_UA.ts
+++ b/translations/qdiskinfo_uk_UA.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_uk_UA.ts
+++ b/translations/qdiskinfo_uk_UA.ts
@@ -75,8 +75,8 @@
         <translation>Кількість вмикань</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Час роботи</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Температура в Фаренгейтах</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>годин</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_vi_VN.ts
+++ b/translations/qdiskinfo_vi_VN.ts
@@ -75,8 +75,8 @@
         <translation>Power On Count</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>Power On Hours</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;Use Fahrenheit</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>hours</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_zh_CN.ts
+++ b/translations/qdiskinfo_zh_CN.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_zh_CN.ts
+++ b/translations/qdiskinfo_zh_CN.ts
@@ -75,8 +75,8 @@
         <translation>通电次数</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>通电时间</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>使用华氏度 (&amp;U)</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>小时</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>

--- a/translations/qdiskinfo_zh_TW.ts
+++ b/translations/qdiskinfo_zh_TW.ts
@@ -76,7 +76,7 @@
     </message>
     <message>
         <source>Power On Time</source>
-        <translation>Power On Time</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>

--- a/translations/qdiskinfo_zh_TW.ts
+++ b/translations/qdiskinfo_zh_TW.ts
@@ -75,8 +75,8 @@
         <translation>通電次數</translation>
     </message>
     <message>
-        <source>Power On Hours</source>
-        <translation>通電時間</translation>
+        <source>Power On Time</source>
+        <translation>Power On Time</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:700;&quot;&gt;Hard Drive Name&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -129,6 +129,10 @@
     <message>
         <source>&amp;Use Fahrenheit</source>
         <translation>&amp;使用 華氏溫度</translation>
+    </message>
+    <message>
+        <source>&amp;Use Human Readable Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Self Test</source>
@@ -189,6 +193,14 @@
     <message>
         <source>hours</source>
         <translation>小時</translation>
+    </message>
+    <message>
+        <source>years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>days</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>


### PR DESCRIPTION
Implements #75 as a option in the settings menu.

Left is V0.4, right is this PR: 
<img width="1601" height="629" alt="image" src="https://github.com/user-attachments/assets/cb41aef2-ad61-44ce-82ad-2126508355ec" />
<img width="1601" height="629" alt="image" src="https://github.com/user-attachments/assets/1e9df58a-7c5f-4617-843c-a609e0b63124" />

For whatever reason, running `make` was completely reformatting the `it_IT` translation file.  I left that reformat in this PR as it looked like the prior formatting was not consistent with the other translation files.